### PR TITLE
Add oneway arrow label to oneway roads only

### DIFF
--- a/labels.mss
+++ b/labels.mss
@@ -456,16 +456,18 @@
 /* ONE-WAY ARROWS
 /* ================================================================== */
 
-#motorway_label[oneway!=0][zoom>=16],
-#mainroad_label[oneway!=0][zoom>=16],
-#minorroad_label[oneway!=0][zoom>=16] {
-  marker-placement:line;
-  marker-max-error: 0.5;
-  marker-spacing: 200;
-  marker-file: url(img/icon/oneway.svg);
-  [oneway=-1] { marker-file: url(img/icon/oneway-reverse.svg); }
-  [zoom=16] { marker-transform: "scale(0.5)"; }
-  [zoom=17] { marker-transform: "scale(0.75)"; }
+#motorway_label,
+#mainroad_label,
+#minorroad_label {
+  [oneway!=''][oneway!='no'][zoom>=16] {
+    marker-placement:line;
+    marker-max-error: 0.5;
+    marker-spacing: 200;
+    marker-file: url(img/icon/oneway.svg);
+    [oneway=-1] { marker-file: url(img/icon/oneway-reverse.svg); }
+    [zoom=16] { marker-transform: "scale(0.5)"; }
+    [zoom=17] { marker-transform: "scale(0.75)"; }
+  }
 }
 
 


### PR DESCRIPTION
Hi,
when using the `swiss style` on http://www.osm.ch/, I noticed that all roads with a name also had a oneway arrow. I could reproduce this in TileMill, and the patch in this pull request should fix that.
