### PR TITLE
fixes for easier use of mapnik xml

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -295,7 +295,8 @@
       "id": "swisshills",
       "class": "",
       "Datasource": {
-        "file": "img/swiss-hills.tif"
+        "file": "img/swiss-hills.tif",
+        "type": "gdal"
       },
       "srs-name": "900913",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",


### PR DESCRIPTION
Two fixes to make it easier to just convert style sheet with carto to mapnik xml and render tiles with mod_tile

type gdal is needed for mapnik to recognize it as an image layer

the other layer seems not to be used and is also rejected by mapnik
